### PR TITLE
Change Priority to Critical if Urgent Feature

### DIFF
--- a/EmergencyServices/BackendHelper.cs
+++ b/EmergencyServices/BackendHelper.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -87,5 +88,89 @@ namespace EmergencyServices.Group8
 
             return processedDisaster;
         }
+
+        public static async Task<List<TestProcessedDisaster>> GetAllTestProcessedDisastersAsync()
+        {
+            try
+            {
+                //Query the 'test_disaster_processed' table
+                var response = await supabase
+                    .From<TestProcessedDisaster>()   // Target the test table model
+                    .Select("*")
+                    .Get();
+
+                return response.Models;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error retrieving processed disasters from test_disaster_processed table: {ex.Message}");
+                return new List<TestProcessedDisaster>();
+            }
+        }
+
+        public static async Task<List<TestProcessedDisaster>> GetTestDisastersByPriorityAsync(DisasterTypeEnums priorityLevel)
+        {
+            try
+            {
+                string priorityAsString = priorityLevel.ToString();
+                Debug.WriteLine($"Filtering test table for priority: {priorityAsString}");
+
+                // Query the 'test_disaster_processed' table to filter by priority level
+                var response = await supabase
+                    .From<TestProcessedDisaster>()    // Target the test model
+                    .Select("*")
+                    .Filter(x => x.Priority, Postgrest.Constants.Operator.Equals, priorityAsString)
+                    .Get();
+
+                return response.Models;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error retrieving disasters with priority '{priorityLevel}' from test table: {ex.Message}");
+                return new List<TestProcessedDisaster>();
+            }
+        }
+
+        public static async Task<bool> MarkTestDisasterAsCriticalAsync(int disasterId)
+        {
+            try
+            {
+                // Retrieve the current disaster by ID
+                var currentDisasterResponse = await supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Get();
+
+                var currentDisaster = currentDisasterResponse.Models.FirstOrDefault();
+
+                if (currentDisaster == null)
+                {
+                    Debug.WriteLine("Test disaster not found.");
+                    return false;
+                }
+
+                if (currentDisaster.Priority != "Urgent")
+                {
+                    Debug.WriteLine("Test disaster priority is not 'Urgent', cannot update to 'Critical'.");
+                    return false;
+                }
+
+                // Update the priority to 'Critical'
+                var updatedDisaster = new { Priority = "Critical" };
+
+                var response = await supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Update(updatedDisaster);
+
+                return response.Models.Count > 0;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error marking test disaster as critical: {ex.Message}");
+                return false;
+            }
+        }
+
     }
 }

--- a/EmergencyServices/EmergencyBackend.cs
+++ b/EmergencyServices/EmergencyBackend.cs
@@ -46,9 +46,9 @@ namespace EmergencyServices.Group8
         {
             try
             {
-                // Query the 'disaster_processed' table
+                //Query the 'disaster_processed' table
                 var response = await supabase
-                    .From<ProcessedDisaster>()   // Target the production table model
+                    .From<ProcessedDisaster>()   //Target the production table model
                     .Select("*")
                     .Get();
 
@@ -61,26 +61,6 @@ namespace EmergencyServices.Group8
             }
         }
 
-        public static async Task<List<TestProcessedDisaster>> GetAllTestProcessedDisastersAsync()
-        {
-            try
-            {
-                // Query the 'test_disaster_processed' table
-                var response = await supabase
-                    .From<TestProcessedDisaster>()   // Target the test table model
-                    .Select("*")
-                    .Get();
-
-                return response.Models;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error retrieving processed disasters from test_disaster_processed table: {ex.Message}");
-                return new List<TestProcessedDisaster>();
-            }
-        }
-
-
         public static async Task<List<ProcessedDisaster>> GetDisastersByPriorityAsync(DisasterTypeEnums priorityLevel)
         {
             try
@@ -88,9 +68,9 @@ namespace EmergencyServices.Group8
                 string priorityAsString = priorityLevel.ToString();
                 Debug.WriteLine($"Filtering production table for priority: {priorityAsString}");
 
-                // Query the 'disaster_processed' table to filter by priority level
+                //Query the 'disaster_processed' table to filter by priority level
                 var response = await supabase
-                    .From<ProcessedDisaster>()    // Target the production model
+                    .From<ProcessedDisaster>()    //Target the production model
                     .Select("*")
                     .Filter(x => x.Priority, Postgrest.Constants.Operator.Equals, priorityAsString)
                     .Get();
@@ -104,28 +84,48 @@ namespace EmergencyServices.Group8
             }
         }
 
-        public static async Task<List<TestProcessedDisaster>> GetTestDisastersByPriorityAsync(DisasterTypeEnums priorityLevel)
+        public static async Task<bool> MarkDisasterAsCriticalAsync(int disasterId)
         {
             try
             {
-                string priorityAsString = priorityLevel.ToString();
-                Debug.WriteLine($"Filtering test table for priority: {priorityAsString}");
-
-                // Query the 'test_disaster_processed' table to filter by priority level
-                var response = await supabase
-                    .From<TestProcessedDisaster>()    // Target the test model
-                    .Select("*")
-                    .Filter(x => x.Priority, Postgrest.Constants.Operator.Equals, priorityAsString)
+                //Step 1: Retrieve the current disaster by ID
+                var currentDisasterResponse = await supabase
+                    .From<ProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
                     .Get();
 
-                return response.Models;
+                var currentDisaster = currentDisasterResponse.Models.FirstOrDefault();
+
+                //Step 2: Check if the current priority is 'Urgent'
+                if (currentDisaster == null)
+                {
+                    Debug.WriteLine("Disaster not found.");
+                    return false;
+                }
+
+                if (currentDisaster.Priority != "Urgent")
+                {
+                    Debug.WriteLine("Disaster priority is not 'Urgent', cannot update to 'Critical'.");
+                    return false;
+                }
+
+                //Step 3: Update the priority to 'Critical'
+                var updatedDisaster = new { Priority = "Critical" };
+
+                var response = await supabase
+                    .From<ProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Update(updatedDisaster);
+
+                return response.Models.Count > 0; //Returns true if at least one record was updated
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Error retrieving disasters with priority '{priorityLevel}' from test table: {ex.Message}");
-                return new List<TestProcessedDisaster>();
+                Debug.WriteLine($"Error marking disaster as critical: {ex.Message}");
+                return false; //Return false if an error occurs
             }
         }
+
 
         //public static async Task LoadPdfContentToSupabase(string pdfFilePath)
         //{

--- a/EmergencyServices_Group8_Tests/UnitTest.cs
+++ b/EmergencyServices_Group8_Tests/UnitTest.cs
@@ -201,5 +201,110 @@ namespace EmergencyServices_Group8_Tests
             Assert.AreEqual(initialCount, finalCount);
         }
 
+        [TestMethod]
+        public async Task Test_MarkDisasterAsCriticalAsync_OnlyWhenUrgent()
+        {
+            if (EmergencyBackend.supabase == null)
+            {
+                EmergencyBackend.Init();
+            }
+
+            //Step 1: Insert a disaster with a non-'Urgent' priority
+            var testDisaster = new TestProcessedDisaster
+            {
+                DisasterType = "Flood",
+                Priority = "Warning", // Not 'Urgent'
+                Description = "Test flood warning.",
+                PrecautionSteps = "Test precaution steps.",
+                DuringDisasterSteps = "Test during disaster steps.",
+                RecoverySteps = "Test recovery steps.",
+                Timestamp = DateTime.Now,
+                SeverityLevel = 3.0,
+                Source = "NWS"
+            };
+
+            var insertResponse = await EmergencyBackend.supabase.From<TestProcessedDisaster>().Insert(testDisaster);
+            Assert.IsTrue(insertResponse.Models.Count > 0, "Failed to insert test disaster.");
+
+            int disasterId = insertResponse.Models[0].Id;
+
+            try
+            {
+                //Step 2: Attempt to mark it as 'Critical' (should fail)
+                bool success = await BackendHelper.MarkTestDisasterAsCriticalAsync(disasterId);
+                Assert.IsFalse(success, "Disaster was incorrectly updated to 'Critical' despite not being 'Urgent'.");
+
+                //Step 3: Update the disaster to 'Urgent' and retry
+                await EmergencyBackend.supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Update(new { Priority = "Urgent" });
+
+                success = await BackendHelper.MarkTestDisasterAsCriticalAsync(disasterId);
+                Assert.IsTrue(success, "Failed to update disaster to 'Critical' when priority was 'Urgent'.");
+            }
+            finally
+            {
+                //Cleanup: Remove the inserted disaster
+                await EmergencyBackend.supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Delete();
+            }
+        }
+
+        [TestMethod]
+        public async Task Test_MarkDisasterAsCriticalAsync_UpdatesToCritical()
+        {
+            if (EmergencyBackend.supabase == null)
+            {
+                EmergencyBackend.Init();
+            }
+
+            //Step 1: Insert a disaster with 'Urgent' priority
+            var testDisaster = new TestProcessedDisaster
+            {
+                DisasterType = "Hurricane",
+                Priority = "Urgent", // This should allow it to update to 'Critical'
+                Description = "Test hurricane warning.",
+                PrecautionSteps = "Test precaution steps for hurricane.",
+                DuringDisasterSteps = "Test during disaster steps for hurricane.",
+                RecoverySteps = "Test recovery steps for hurricane.",
+                Timestamp = DateTime.Now,
+                SeverityLevel = 5.0,
+                Source = "NWS"
+            };
+
+            var insertResponse = await EmergencyBackend.supabase.From<TestProcessedDisaster>().Insert(testDisaster);
+            Assert.IsTrue(insertResponse.Models.Count > 0, "Failed to insert test disaster.");
+
+            int disasterId = insertResponse.Models[0].Id;
+
+            try
+            {
+                //Step 2: Attempt to mark it as 'Critical' (should succeed)
+                bool success = await BackendHelper.MarkTestDisasterAsCriticalAsync(disasterId);
+                Assert.IsTrue(success, "Failed to update disaster to 'Critical' when priority was 'Urgent'.");
+
+                //Step 3: Verify the update
+                var updatedDisasterResponse = await EmergencyBackend.supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Get();
+
+                var updatedDisaster = updatedDisasterResponse.Models.FirstOrDefault();
+                Assert.IsNotNull(updatedDisaster, "Updated disaster not found.");
+                Assert.AreEqual("Critical", updatedDisaster.Priority, "Disaster priority was not updated to 'Critical'.");
+            }
+            finally
+            {
+                //Cleanup: Remove the inserted disaster
+                await EmergencyBackend.supabase
+                    .From<TestProcessedDisaster>()
+                    .Where(d => d.Id == disasterId)
+                    .Delete();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Added:
- Function to update priority of pre-existing disaster entry if current priority is urgent (and a test version too)
- Two tests, one for a successful update and one for a failed update.
